### PR TITLE
Minor fix to Wordpress image processor.

### DIFF
--- a/blog2epub/crawlers/wordpress.py
+++ b/blog2epub/crawlers/wordpress.py
@@ -105,8 +105,7 @@ class ArticleWordpressCom(Article):
                     img_parent = img.getparent()
                     if img_parent:
                         if img_hash:
-                            blog2epub_img = f"#blog2epubimage#{img_hash}#"
-                            img_parent.text = blog2epub_img
+                            img_parent.replace(img, etree.Comment(f"#blog2epubimage#{img_hash}#"))
                         else:
                             img_parent.text = ""
                         self.tree = img_parent.getroottree()
@@ -123,7 +122,7 @@ class ArticleWordpressCom(Article):
             img_caption = img_tr.xpath('//p[@class="wp-caption-text"]/text()').pop()
             img_hash = self.downloader.download_image(img_url)
             img_parent = img.getparent()
-            img_parent.replace(img, etree.Comment(f"#blog2epubimage#{img_hash}"))
+            img_parent.replace(img, etree.Comment(f"#blog2epubimage#{img_hash}#"))
             self.tree = img_parent.getroottree()
             self.html = etree.tostring(self.tree).decode("utf-8")
             self.images.append(img_hash)
@@ -145,6 +144,7 @@ class ArticleWordpressCom(Article):
                 self.html = self.html.replace(
                     "<!--#blog2epubimage#" + image + "#-->", image_html
                 )
+        self.content = self.html
 
     def get_content(self):
         article_header = re.findall(


### PR DESCRIPTION
Heya! I was trying to use this on a blog I wanted to download before a long train ride, and I noticed none of the images were being formatted properly. I noticed a few issues:

- In `get_single_images()` the `blog2epubimage` tag was prepended to the existing `<img>` tag, leaving it there even after processing.
 - It also did not insert a comment, so the find/replace never matched the tag.
- In `get_images_with_captions()` the inserted tag did not end with a `#` so the find/replace never matched the tag.
- The final output took from `article.content` whereas `replace_images()` only ever affected `article.html`

Hopefully the changes I've made make sense, they should address all of the above issues and I was able to compile a functional epub using these edits, just in time for my train too.

Thank you very much for this project, I've used it a fair few times and find it very useful. Hope you find my little contribution helpful :grin:.