### PR TITLE
Handle when start date is None

### DIFF
--- a/blog2epub/common/book.py
+++ b/blog2epub/common/book.py
@@ -107,6 +107,8 @@ class Book:
             self.interface.print(f"Can't set locale as {self.configuration.language}, but nevermind.")
 
     def _get_subtitle(self):
+        if self.start is None:
+            return ""
         if self.end is None:
             return self.start.strftime("%d %B %Y")
         if self.start.strftime("%Y.%m") == self.end.strftime("%Y.%m"):


### PR DESCRIPTION
When I tried using blog2epub on https://woltman.com, there was no start or end dates so the program would fail in the _get_subtitle() function with ``AttributeError: 'NoneType' object has no attribute 'strftime'``.  

Returns an empty subtitle if the start date is None.